### PR TITLE
Feature/fastify routes

### DIFF
--- a/controller/cardController.js
+++ b/controller/cardController.js
@@ -1,0 +1,23 @@
+import {moonCards} from '../data/moonData'
+import {nanoid} from 'nanoid'
+
+export const getCard = (request, reply) => {
+	const {id} = request.params
+	const card = moonCards.find((card) => card.id === id)
+	if (card) {
+		reply.send(card)
+	} else {
+		reply.code(404).send()
+	}
+}
+
+export const getCards = (request, reply) => {
+	reply.send(moonCards)
+}
+
+export const postCard = (request, reply) => {
+	const card = request.body
+	card.id = nanoid()
+	moonCards.push(card)
+	reply.send(card)
+}

--- a/controller/cardController.js
+++ b/controller/cardController.js
@@ -32,5 +32,5 @@ export const updateCard = (request, reply) => {
 export const deleteCard = (request, reply) => {
 	const index = moonCards.findIndex((c) => c.id === request.params.id)
 	moonCards.splice(index, 1)
-	reply.send(moonCards)
+	reply.send(`Card with id ${request.params.id} deleted`)
 }

--- a/controller/cardController.js
+++ b/controller/cardController.js
@@ -15,9 +15,22 @@ export const getCards = (request, reply) => {
 	reply.send(moonCards)
 }
 
-export const postCard = (request, reply) => {
+export const addCard = (request, reply) => {
 	const card = request.body
 	card.id = nanoid()
 	moonCards.push(card)
 	reply.send(card)
+}
+
+export const updateCard = (request, reply) => {
+	const card = request.body
+	const index = moonCards.findIndex((c) => c.id === request.params.id)
+	moonCards[index] = card
+	reply.send(card)
+}
+
+export const deleteCard = (request, reply) => {
+	const index = moonCards.findIndex((c) => c.id === request.params.id)
+	moonCards.splice(index, 1)
+	reply.send(moonCards)
 }

--- a/data/moonData.js
+++ b/data/moonData.js
@@ -1,4 +1,4 @@
-export const moonData = [
+export const moonCards = [
 	{
 		id: 'w1',
 		talent: 'wisdom',

--- a/moonData.js
+++ b/moonData.js
@@ -1,363 +1,363 @@
-export const cards = [
+export const moonData = [
 	{
-		code: 'w1',
+		id: 'w1',
 		talent: 'wisdom',
 		terms: 'Read a spiritual book for',
 		count: 1,
 		intervals: 'chapters'
 	},
 	{
-		code: 'w2',
+		id: 'w2',
 		talent: 'wisdom',
 		terms: 'Ask someone older than you and take down',
 		count: 2,
 		intervals: 'notes'
 	},
 	{
-		code: 'w3',
+		id: 'w3',
 		talent: 'wisdom',
 		terms: 'Read health and wellness',
 		count: 3,
 		intervals: 'articles'
 	},
 	{
-		code: 'w4',
+		id: 'w4',
 		talent: 'wisdom',
 		terms: 'Call someone you love and talk to them for at least',
 		count: 4,
 		intervals: 'minutes'
 	},
 	{
-		code: 'w5',
+		id: 'w5',
 		talent: 'wisdom',
 		terms: 'Google',
 		count: 5,
 		intervals: 'interests'
 	},
 	{
-		code: 'w6',
+		id: 'w6',
 		talent: 'wisdom',
 		terms: 'Engage philosophy, google someone for',
 		count: 6,
 		intervals: 'minutes'
 	},
 	{
-		code: 'w7',
+		id: 'w7',
 		talent: 'wisdom',
 		terms: 'Enjoy scenary, stare through the window for',
 		count: 7,
 		intervals: 'minutes'
 	},
 	{
-		code: 'w8',
+		id: 'w8',
 		talent: 'wisdom',
 		terms: 'self-reflect, look at a mirror for',
 		count: 8,
 		intervals: 'minutes'
 	},
 	{
-		code: 'w9',
+		id: 'w9',
 		talent: 'wisdom',
 		terms: 'find a self-care book and read ',
 		count: 9,
 		Intervals: 'Pages'
 	},
 	{
-		code: 'w10',
+		id: 'w10',
 		talent: 'wisdom',
 		terms: 'write about',
 		count: 10,
 		intervals: 'things'
 	},
 	{
-		code: 'w11',
+		id: 'w11',
 		talent: 'wisdom',
 		terms: 'write about your day has affected you',
 		count: 11,
 		intervals: 'minutes'
 	},
 	{
-		code: 'w12',
+		id: 'w12',
 		talent: 'wisdom',
 		terms: 'Write different things you love for ',
 		count: 12,
 		intervals: 'counts'
 	},
 	{
-		code: 'w13',
+		id: 'w13',
 		talent: 'wisdom',
 		terms: 'Incite wisdom to a friend, talk to them for',
 		count: 13,
 		intervals: 'meditate'
 	},
 	{
-		code: 's1',
+		id: 's1',
 		talent: 'spirit',
 		terms: 'Tell someone them how much you care about them and what they have done to improve your life for',
 		count: 1,
 		intervals: 'phonecall'
 	},
 	{
-		code: 's2',
+		id: 's2',
 		talent: 'spirit',
 		terms: 'pray',
 		count: 2,
 		intervals: 'minutes'
 	},
 	{
-		code: 's3',
+		id: 's3',
 		talent: 'spirit',
 		terms: 'Find some space and meditate for',
 		count: 3,
 		intervals: 'minutes'
 	},
 	{
-		code: 's4',
+		id: 's4',
 		talent: 'spirit',
 		terms: 'Read about a spiritual article',
 		count: 4,
 		intervals: 'minutes'
 	},
 	{
-		code: 's5',
+		id: 's5',
 		talent: 'spirit',
 		terms: 'pray for',
 		count: 5,
 		intervals: 'minutes'
 	},
 	{
-		code: 's6',
+		id: 's6',
 		talent: 'spirit',
 		terms: 'write down good things that have happened to you today',
 		count: 6,
 		intervals: 'items'
 	},
 	{
-		code: 's7',
+		id: 's7',
 		talent: 'spirit',
 		terms: 'Meditate for',
 		count: 7,
 		intervals: 'pages'
 	},
 	{
-		code: 's8',
+		id: 's8',
 		talent: 'spirit',
 		terms: 'Count your blessings and write them for',
 		count: 8,
 		intervals: 'minutes'
 	},
 	{
-		code: 's9',
+		id: 's9',
 		talent: 'spirit',
 		terms: 'Light a candle and stare at it for',
 		count: 9,
 		intervals: 'minutes'
 	},
 	{
-		code: 's10',
+		id: 's10',
 		talent: 'spirit',
 		terms: 'List what you are grateful for',
 		count: 10,
 		intervals: 'nouns'
 	},
 	{
-		code: 's11',
+		id: 's11',
 		talent: 'spirit',
 		terms: 'Write to the world for',
 		count: 11,
 		intervals: 'minutes'
 	},
 	{
-		code: 's12',
+		id: 's12',
 		talent: 'spirit',
 		terms: 'do guided meditation for',
 		count: 12,
 		intervals: 'chapters'
 	},
 	{
-		code: 's13',
+		id: 's13',
 		talent: 'spirit',
 		terms: 'do 5 downward dogs for',
 		count: 13,
 		intervals: 'seconds each'
 	},
 	{
-		code: 'v1',
+		id: 'v1',
 		talent: 'Vitality',
 		terms: 'Pace the Earth, Run for',
 		count: 1,
 		intervals: 'Miles'
 	},
 	{
-		code: 'v2',
+		id: 'v2',
 		talent: 'Vitality',
 		terms: 'Do pushups for a total of ',
 		count: 2,
 		intervals: 'minutes'
 	},
 	{
-		code: 'v3',
+		id: 'v3',
 		talent: 'Vitality',
 		terms: 'Hug the floor, do planks for',
 		count: 3,
 		intervals: 'minutes'
 	},
 	{
-		code: 'v4',
+		id: 'v4',
 		talent: 'Vitality',
 		terms: 'Do sit ups for',
 		count: 4,
 		intervals: 'Reps of 10'
 	},
 	{
-		code: 'v5',
+		id: 'v5',
 		talent: 'Vitality',
 		terms: 'Jump rope',
 		count: 5,
 		intervals: 'Reps of 20'
 	},
 	{
-		code: 'v6',
+		id: 'v6',
 		talent: 'Vitality',
 		terms: 'Do burpees',
 		count: 6,
 		intervals: 'Reps of 5'
 	},
 	{
-		code: 'v7',
+		id: 'v7',
 		talent: 'Vitality',
 		terms: 'Do cat and cow stretch',
 		count: 7,
 		intervals: 'times'
 	},
 	{
-		code: 'v8',
+		id: 'v8',
 		talent: 'Vitality',
 		terms: 'Drink glass of water',
 		count: 8,
 		intervals: 'ounces'
 	},
 	{
-		code: 'v9',
+		id: 'v9',
 		talent: 'Vitality',
 		terms: 'Do squats',
 		count: 9,
 		intervals: 'Reps of 5'
 	},
 	{
-		code: 'v10',
+		id: 'v10',
 		talent: 'Vitality',
 		terms: 'Stretch',
 		count: 10,
 		intervals: 'Minutes'
 	},
 	{
-		code: 'v11',
+		id: 'v11',
 		talent: 'Vitality',
 		terms: 'Touch your toes',
 		count: 11,
 		intervals: 'Times'
 	},
 	{
-		code: 'v12',
+		id: 'v12',
 		talent: 'Vitality',
 		terms: 'Do jump squats for',
 		count: 12,
 		intervals: 'Reps of 2'
 	},
 	{
-		code: 'v13',
+		id: 'v13',
 		talent: 'Vitality',
 		terms: 'Do slow calf raises for',
 		count: 13,
 		intervals: 'Sets of 2'
 	},
 	{
-		code: 'm1',
+		id: 'm1',
 		talent: 'Mind',
 		terms: 'Learn something new and read ',
 		count: 1,
 		intervals: 'article'
 	},
 	{
-		code: 'm2',
+		id: 'm2',
 		talent: 'Mind',
 		terms: 'Learn something new about your hobby and read',
 		count: 2,
 		intervals: 'articles'
 	},
 	{
-		code: 'm3',
+		id: 'm3',
 		talent: 'Mind',
 		terms: 'Learn something new and read ',
 		count: 3,
 		intervals: 'article'
 	},
 	{
-		code: 'm4',
+		id: 'm4',
 		talent: 'Mind',
 		terms: 'Google a riddle and try to solve it in ',
 		count: 4,
 		intervals: 'minutes'
 	},
 	{
-		code: 'm5',
+		id: 'm5',
 		talent: 'Mind',
 		terms: 'Read a non-fiction book for ',
 		count: 5,
 		intervals: 'minutes'
 	},
 	{
-		code: 'm6',
+		id: 'm6',
 		talent: 'Mind',
 		terms: 'Read a non-fiction book for',
 		count: 6,
 		intervals: 'minutes'
 	},
 	{
-		code: 'm7',
+		id: 'm7',
 		talent: 'Mind',
 		terms: 'Learn something new and read articles for ',
 		count: 7,
 		intervals: 'minutes'
 	},
 	{
-		code: 'm8',
+		id: 'm8',
 		talent: 'Mind',
 		terms: 'Teach something to someone for',
 		count: 8,
 		intervals: 'minutes'
 	},
 	{
-		code: 'm9',
+		id: 'm9',
 		talent: 'Mind',
 		terms: 'Have someone teach you something for',
 		count: 9,
 		intervals: 'minutes'
 	},
 	{
-		code: 'm10',
+		id: 'm10',
 		talent: 'Mind',
 		terms: 'Read a non-fiction book for',
 		count: 10,
 		intervals: 'minutes'
 	},
 	{
-		code: 'm11',
+		id: 'm11',
 		talent: 'Mind',
 		terms: 'Read a non-fiction book for',
 		count: 11,
 		intervals: 'minutes'
 	},
 	{
-		code: 'm12',
+		id: 'm12',
 		talent: 'Mind',
 		terms: 'Read either 1 or',
 		count: 12,
 		intervals: 'chapters'
 	},
 	{
-		code: 'm13',
+		id: 'm13',
 		talent: 'Mind',
 		terms: 'Read 3 articles or read for',
 		count: 13,

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
 	"type": "module",
 	"main": "server.js",
 	"scripts": {
-		"start": "node server",
-		"dev": "nodemon server"
+		"start": "node --experimental-specifier-resolution=node server.js",
+		"dev": "nodemon --experimental-specifier-resolution=node server.js"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"@vercel/node": "^1.12.1",
 		"fastify": "^3.25.3",
 		"fastify-swagger": "^4.13.0",
-		"uuid": "^8.3.2"
+		"nanoid": "^3.1.30"
 	},
 	"keywords": [],
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 	"dependencies": {
 		"@vercel/node": "^1.12.1",
 		"fastify": "^3.25.3",
+		"fastify-cors": "^6.0.2",
 		"fastify-swagger": "^4.13.0",
 		"nanoid": "^3.1.30"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,14 +4,14 @@ specifiers:
   '@vercel/node': ^1.12.1
   fastify: ^3.25.3
   fastify-swagger: ^4.13.0
+  nanoid: ^3.1.30
   nodemon: ^2.0.15
-  uuid: ^8.3.2
 
 dependencies:
   '@vercel/node': 1.12.1
   fastify: 3.25.3
   fastify-swagger: 4.13.0
-  uuid: 8.3.2
+  nanoid: 3.1.30
 
 devDependencies:
   nodemon: 2.0.15
@@ -818,6 +818,12 @@ packages:
   /ms/2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  /nanoid/3.1.30:
+    resolution: {integrity: sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: false
+
   /nodemon/2.0.15:
     resolution: {integrity: sha512-gdHMNx47Gw7b3kWxJV64NI+Q5nfl0y5DgDbiVtShiwa7Z0IZ07Ll4RLFo6AjrhzMtoEZn5PDE3/c2AbVsiCkpA==}
     engines: {node: '>=8.10.0'}
@@ -1285,11 +1291,6 @@ packages:
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=}
-    dev: false
-
-  /uuid/8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    hasBin: true
     dev: false
 
   /widest-line/3.1.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: 5.3
 specifiers:
   '@vercel/node': ^1.12.1
   fastify: ^3.25.3
+  fastify-cors: ^6.0.2
   fastify-swagger: ^4.13.0
   nanoid: ^3.1.30
   nodemon: ^2.0.15
@@ -10,6 +11,7 @@ specifiers:
 dependencies:
   '@vercel/node': 1.12.1
   fastify: 3.25.3
+  fastify-cors: 6.0.2
   fastify-swagger: 4.13.1
   nanoid: 3.1.30
 
@@ -403,6 +405,13 @@ packages:
 
   /fast-safe-stringify/2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+    dev: false
+
+  /fastify-cors/6.0.2:
+    resolution: {integrity: sha512-sE0AOyzmj5hLLRRVgenjA6G2iOGX35/1S3QGYB9rr9TXelMZB3lFrXy4CzwYVOMiujJeMiLgO4J7eRm8sQSv8Q==}
+    dependencies:
+      fastify-plugin: 3.0.0
+      vary: 1.1.2
     dev: false
 
   /fastify-error/0.3.1:
@@ -1291,6 +1300,11 @@ packages:
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=}
+    dev: false
+
+  /vary/1.1.2:
+    resolution: {integrity: sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=}
+    engines: {node: '>= 0.8'}
     dev: false
 
   /widest-line/3.1.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ specifiers:
 dependencies:
   '@vercel/node': 1.12.1
   fastify: 3.25.3
-  fastify-swagger: 4.13.0
+  fastify-swagger: 4.13.1
   nanoid: 3.1.30
 
 devDependencies:
@@ -425,8 +425,8 @@ packages:
       send: 0.17.2
     dev: false
 
-  /fastify-swagger/4.13.0:
-    resolution: {integrity: sha512-HQ4059nlrOaJ20opGP+9KXBtxobEgovLOov2BPsqaNkLpFyPcddoYoLeiQur4YuB53rxUE1mnGMLIPXKwvcwbg==}
+  /fastify-swagger/4.13.1:
+    resolution: {integrity: sha512-9MQ+YVo/2F9Bg2tXs5POccHau5znmHaneggjoyinqumD+n7wClu4uYwV8cNMikdr7zvoepVaYedPue1xHQwsgg==}
     dependencies:
       fastify-plugin: 3.0.0
       fastify-static: 4.5.0

--- a/routes/cards.js
+++ b/routes/cards.js
@@ -1,78 +1,101 @@
-import {moonData} from '../moonData'
+import {getCard, getCards, postCard} from '../controller/cardController'
 
-// Options for get /cards
-const getCards = {
-	schema: {
-		response: {
-			200: {
-				type: 'object',
-				properties: {
-					cards: {
-						type: 'array',
-						items: {
-							type: 'object',
-							properties: {
-								id: {
-									type: 'string'
-								},
-								talent: {
-									type: 'string'
-								},
-								terms: {
-									type: 'string'
-								},
-								count: {
-									type: 'number'
-								}
-								// intervals: {
-								// 	type: 'string'
-								// }
-							}
-						}
-					}
-				}
-			}
+// Card Schema
+
+const card = {
+	type: 'object',
+	properties: {
+		id: {
+			type: 'string'
+		},
+		talent: {
+			type: 'string'
+		},
+		terms: {
+			type: 'string'
+		},
+		count: {
+			type: 'number'
+		},
+		intervals: {
+			type: 'string'
 		}
 	}
 }
 
-export const cardRoutes = (fastify, opts, next) => {
+// Schema for the cards
+const getAllCards = {
+	schema: {
+		response: {
+			200: {
+				type: 'array',
+				cards: card
+			}
+		}
+	},
+	handler: getCards
+}
+
+const getSingleCard = {
+	schema: {
+		response: {
+			200: card
+		}
+	},
+	handler: getCard
+}
+
+const addCard = {
+	schema: {
+		body: {
+			type: 'object',
+			required: ['talent', 'terms', 'count', 'interval'],
+			properties: {
+				talent: {
+					type: 'string'
+				},
+				terms: {
+					type: 'string'
+				},
+				count: {
+					type: 'number'
+				},
+				interval: {
+					type: 'string'
+				}
+			}
+		},
+		response: {
+			200: card
+		}
+	},
+	handler: postCard
+}
+
+export const cardRoutes = (fastify, opts, done) => {
 	// GET /cards - returns all cards
-	fastify.get('/api/cards', async (request, reply) => {
-		await reply.send(moonData)
-	})
+	fastify.get('/cards', getAllCards)
 
 	// GET /cards/:id - returns card with matching id
-	fastify.get('/api/cards/:id', getCards, async (request, reply) => {
-		const card = moonDatafind((card) => card.id === request.params.id)
-		if (card) {
-			await reply.send(card)
-		} else {
-			await reply.send(null)
-		}
-	})
+	fastify.get('/cards/:id', getSingleCard)
 
 	// POST /cards - creates a new card
-	fastify.post('/api/cards', async (request, reply) => {
-		const card = request.body
-		moonDatapush(card)
-		await reply.send(card)
-	})
+	fastify.post('/cards', addCard)
 
 	// PUT /cards/:id - updates card with matching id
-	fastify.put('/api/cards/:id', async (request, reply) => {
-		const card = request.body
-		const index = moonDatafindIndex((c) => c.id === request.params.id)
-		cards[index] = card
-		await reply.send(card)
-	})
+	// fastify.put('/api/cards/:id', async (request, reply) => {
+	// 	const card = request.body
+	// 	const index = moonCardsfindIndex((c) => c.id === request.params.id)
+	// 	cards[index] = card
+	// 	await reply.send(card)
+	// })
 
-	// DELETE /cards/:id - deletes card with matching id
-	fastify.delete('/api/cards/:id', async (request, reply) => {
-		const index = moonDatafindIndex((c) => c.id === request.params.id)
-		moonDatasplice(index, 1)
-		await reply.send(cards)
-	})
+	// // DELETE /cards/:id - deletes card with matching id
+	// fastify.delete('/api/cards/:id', async (request, reply) => {
+	// 	const index = moonCardsfindIndex((c) => c.id === request.params.id)
+	// 	moonCardssplice(index, 1)
+	// 	await reply.send(cards)
+	// })
 
-	next()
+	done()
 }

--- a/routes/cards.js
+++ b/routes/cards.js
@@ -1,6 +1,5 @@
-import {getCard, getCards, postCard} from '../controller/cardController'
-
-// Card Schema
+import fastify from 'fastify'
+import {getCards, addCard, getCard, updateCard, deleteCard} from '../controller/cardController'
 
 const card = {
 	type: 'object',
@@ -17,85 +16,93 @@ const card = {
 		count: {
 			type: 'number'
 		},
-		intervals: {
+		interval: {
 			type: 'string'
 		}
 	}
 }
 
-// Schema for the cards
-const getAllCards = {
-	schema: {
+const routesConfig = [
+	{
+		method: 'GET',
+		path: '/cards',
+		handler: getCards,
 		response: {
-			200: {
+			schema: {
 				type: 'array',
-				cards: card
+				items: card
 			}
 		}
 	},
-	handler: getCards
-}
-
-const getSingleCard = {
-	schema: {
+	{
+		method: 'POST',
+		path: '/cards',
+		handler: addCard,
 		response: {
-			200: card
+			schema: card
+		},
+		config: {
+			validate: {
+				payload: card
+			}
 		}
 	},
-	handler: getCard
-}
-
-const addCard = {
-	schema: {
-		body: {
-			type: 'object',
-			required: ['talent', 'terms', 'count', 'interval'],
-			properties: {
-				talent: {
-					type: 'string'
-				},
-				terms: {
-					type: 'string'
-				},
-				count: {
-					type: 'number'
-				},
-				interval: {
-					type: 'string'
+	{
+		method: 'GET',
+		path: '/cards/{id}',
+		handler: getCard,
+		response: {
+			schema: card
+		},
+		config: {
+			validate: {
+				params: {
+					id: {
+						type: 'string'
+					}
 				}
 			}
-		},
-		response: {
-			200: card
 		}
 	},
-	handler: postCard
-}
+	{
+		method: 'PUT',
+		path: '/cards/{id}',
+		handler: updateCard,
+		response: {
+			schema: card
+		},
+		config: {
+			validate: {
+				payload: card
+			}
+		}
+	},
+	{
+		method: 'DELETE',
+		path: '/cards/{id}',
+		handler: deleteCard,
+		response: {
+			schema: {
+				type: 'array',
+				items: card
+			}
+		},
+		config: {
+			validate: {
+				params: {
+					id: {
+						type: 'string'
+					}
+				}
+			}
+		}
+	}
+]
 
-export const cardRoutes = (fastify, opts, done) => {
-	// GET /cards - returns all cards
-	fastify.get('/cards', getAllCards)
-
-	// GET /cards/:id - returns card with matching id
-	fastify.get('/cards/:id', getSingleCard)
-
-	// POST /cards - creates a new card
-	fastify.post('/cards', addCard)
-
-	// PUT /cards/:id - updates card with matching id
-	// fastify.put('/api/cards/:id', async (request, reply) => {
-	// 	const card = request.body
-	// 	const index = moonCardsfindIndex((c) => c.id === request.params.id)
-	// 	cards[index] = card
-	// 	await reply.send(card)
-	// })
-
-	// // DELETE /cards/:id - deletes card with matching id
-	// fastify.delete('/api/cards/:id', async (request, reply) => {
-	// 	const index = moonCardsfindIndex((c) => c.id === request.params.id)
-	// 	moonCardssplice(index, 1)
-	// 	await reply.send(cards)
-	// })
+export const cardRoutes = (fastify, _options, done) => {
+	routesConfig.forEach((routeConfig) => {
+		fastify.route(routeConfig)
+	})
 
 	done()
 }

--- a/routes/cards.js
+++ b/routes/cards.js
@@ -84,14 +84,6 @@ const routesConfig = [
 		path: '/cards/:id',
 		handler: deleteCard,
 		response: {
-			schema: {
-				type: 'object',
-				properties: {
-					message: {
-						type: 'string'
-					}
-				}
-			},
 			statusCode: 200
 		},
 		config: {

--- a/routes/cards.js
+++ b/routes/cards.js
@@ -1,4 +1,3 @@
-import fastify from 'fastify'
 import {getCards, addCard, getCard, updateCard, deleteCard} from '../controller/cardController'
 
 const card = {
@@ -31,7 +30,8 @@ const routesConfig = [
 			schema: {
 				type: 'array',
 				items: card
-			}
+			},
+			statusCode: 200
 		}
 	},
 	{
@@ -39,7 +39,8 @@ const routesConfig = [
 		path: '/cards',
 		handler: addCard,
 		response: {
-			schema: card
+			schema: card,
+			statusCode: 201
 		},
 		config: {
 			validate: {
@@ -49,10 +50,11 @@ const routesConfig = [
 	},
 	{
 		method: 'GET',
-		path: '/cards/{id}',
+		path: '/cards/:id',
 		handler: getCard,
 		response: {
-			schema: card
+			schema: card,
+			statusCode: 200
 		},
 		config: {
 			validate: {
@@ -66,7 +68,7 @@ const routesConfig = [
 	},
 	{
 		method: 'PUT',
-		path: '/cards/{id}',
+		path: '/cards/:id',
 		handler: updateCard,
 		response: {
 			schema: card
@@ -79,13 +81,18 @@ const routesConfig = [
 	},
 	{
 		method: 'DELETE',
-		path: '/cards/{id}',
+		path: '/cards/:id',
 		handler: deleteCard,
 		response: {
 			schema: {
-				type: 'array',
-				items: card
-			}
+				type: 'object',
+				properties: {
+					message: {
+						type: 'string'
+					}
+				}
+			},
+			statusCode: 200
 		},
 		config: {
 			validate: {

--- a/routes/cards.js
+++ b/routes/cards.js
@@ -1,0 +1,78 @@
+import {moonData} from '../moonData'
+
+// Options for get /cards
+const getCards = {
+	schema: {
+		response: {
+			200: {
+				type: 'object',
+				properties: {
+					cards: {
+						type: 'array',
+						items: {
+							type: 'object',
+							properties: {
+								id: {
+									type: 'string'
+								},
+								talent: {
+									type: 'string'
+								},
+								terms: {
+									type: 'string'
+								},
+								count: {
+									type: 'number'
+								}
+								// intervals: {
+								// 	type: 'string'
+								// }
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+export const cardRoutes = (fastify, opts, next) => {
+	// GET /cards - returns all cards
+	fastify.get('/api/cards', async (request, reply) => {
+		await reply.send(moonData)
+	})
+
+	// GET /cards/:id - returns card with matching id
+	fastify.get('/api/cards/:id', getCards, async (request, reply) => {
+		const card = moonDatafind((card) => card.id === request.params.id)
+		if (card) {
+			await reply.send(card)
+		} else {
+			await reply.send(null)
+		}
+	})
+
+	// POST /cards - creates a new card
+	fastify.post('/api/cards', async (request, reply) => {
+		const card = request.body
+		moonDatapush(card)
+		await reply.send(card)
+	})
+
+	// PUT /cards/:id - updates card with matching id
+	fastify.put('/api/cards/:id', async (request, reply) => {
+		const card = request.body
+		const index = moonDatafindIndex((c) => c.id === request.params.id)
+		cards[index] = card
+		await reply.send(card)
+	})
+
+	// DELETE /cards/:id - deletes card with matching id
+	fastify.delete('/api/cards/:id', async (request, reply) => {
+		const index = moonDatafindIndex((c) => c.id === request.params.id)
+		moonDatasplice(index, 1)
+		await reply.send(cards)
+	})
+
+	next()
+}

--- a/server.js
+++ b/server.js
@@ -1,8 +1,21 @@
 import Fastify from 'fastify'
-import {cardRoutes} from './routes/cards.js'
+import fastifySwagger from 'fastify-swagger'
+import {cardRoutes} from './routes/cards'
 
 const fastify = Fastify({
 	logger: true
+})
+
+fastify.register(fastifySwagger, {
+	exposeRoute: true,
+	routePrefix: '/docs',
+	swagger: {
+		info: {
+			title: 'Moon Cards API',
+			description: 'The Moon Cards API for Thirteen Moons',
+			version: '1.0.0'
+		}
+	}
 })
 
 fastify.register(cardRoutes)

--- a/server.js
+++ b/server.js
@@ -1,15 +1,13 @@
 import Fastify from 'fastify'
-import { cards } from './cards.js'
+import {cardRoutes} from './routes/cards.js'
 
 const fastify = Fastify({
 	logger: true
 })
 
-const PORT = process.env.PORT || 3000
+fastify.register(cardRoutes)
 
-fastify.get('/cards', async (request, reply) => {
-	await reply.send(cards)
-})
+const PORT = process.env.PORT || 3000
 
 fastify.listen(PORT, function (err, address){
 	if (err) {

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 import Fastify from 'fastify'
+import fastifyCors from 'fastify-cors'
 import fastifySwagger from 'fastify-swagger'
 import {cardRoutes} from './routes/cards'
 
@@ -19,6 +20,11 @@ fastify.register(fastifySwagger, {
 })
 
 fastify.register(cardRoutes)
+
+fastify.register(fastifyCors, {
+	origin: '*',
+	methods: ['GET', 'POST', 'PUT', 'DELETE']
+})
 
 const PORT = process.env.PORT || 3000
 


### PR DESCRIPTION
# Fastify Routes

The server is officially connected to the front-end of thirteen moons (using only the local host for now). After this PR goes through and vercel updates the server, then the client app will not have to depend on a third-party API. "Routes" have been added to the basic requests you can make on a card.

## Changelog

- Add Fastify routes : getCard, getCards, addCard, updateCard, deleteCard
- Add CORS
- Organize server into folders and separate files.
- Created an API documentation using swagger. Link will be included once I update the README

## Notes

I have to say I really am enjoying Fastify. I really appreciate how modular the setup is and, obviously, how fast it is! I also want the logger (It's like the `Heroku log -tails` command), but it's an option you can add into fastify to see any live HTTPS calls made to the server. It made it a lot easier to troubleshoot any issue I had.



